### PR TITLE
docs: resolve Q1–Q7 (rail sequencing, curve presets, OCE hosting, repo split)

### DIFF
--- a/docs/OPEN_QUESTIONS.md
+++ b/docs/OPEN_QUESTIONS.md
@@ -1,89 +1,6 @@
 # Open Questions
 
-Live decision deck for Bount.ing v2. Decisions move to [V2_THESIS.md](V2_THESIS.md) as they're settled.
-
----
-
-## Q1 — First rail to integrate at v2
-
-**Status:** Open. Pending decision.
-
-The v2 marketplace rides existing pooling rails rather than building its own (Path B, see V2_THESIS.md). The question is which rail to integrate with *first*. Eventually probably multiple; the first one shapes the v2 spec.
-
-| Rail | Why first | Why not |
-|---|---|---|
-| **Drips Network** | Crypto-native. Already supports streaming + multi-sponsor pooling natively. Maps cleanly to the appreciating-bounty mechanic (continuous flow). Operator is crypto-fluent (BASE/ETH wallets exist). Cut-on-close kickback supported. | Crypto-only — restricts sponsor pool to crypto-comfortable. UX overhead for non-crypto sponsors. |
-| **Open Collective** | Fiat-native. Broad maintainer adoption. Fiscal-host model handles compliance globally. | Single-pool-per-project, less granular per-issue than the mechanism design requires. May need creative use of "expenses" to attach bounties to specific issues. |
-| Gitcoin Allo | Quadratic funding primitives match the crowdfunded mechanic well. | Crypto-native like Drips; less mature for per-issue (more matched-round-shaped). |
-| GitHub Sponsors (issue-level) | Closest to existing developer workflow. | Single-sponsor flow only — doesn't support multi-sponsor pooling, which is differentiator #1. Disqualifies as primary rail. |
-
-**Default lean (not yet locked):** Drips first, OC second. Reasoning: appreciation mechanic maps to streaming natively; crypto-fluent operator reduces integration overhead; later add OC for fiat reach.
-
-**To decide:** confirm or flip. Locking this gates the v2 architecture spec.
-
----
-
-## Q2 — Decay/appreciation curve presets
-
-**Status:** Open. Needs concrete numbers.
-
-Three presets named — `urgent` / `standard` / `patient` — but the actual curves aren't specified.
-
-Sketch to react to:
-
-| Preset | Shape | Example |
-|---|---|---|
-| `urgent` | Linear decay over 30 days from initial → floor (e.g. €100 → €25 in 30d) | Security patches, time-sensitive launches |
-| `standard` | Flat for 30 days, then linear decay to floor over the next 60d | Default for typical feature work |
-| `patient` | Linear appreciation, capped at 3× initial or T+90d (whichever first) | Long-tail OSS maintenance |
-
-Open sub-questions:
-- Is "floor" a fixed % of initial (e.g. 25%) or absolute (e.g. €10)?
-- Does the appreciation cap reset if a new sponsor joins the pool, or is it pool-lifetime?
-- What happens after the curve terminates? Bounty expires? Stays at floor/cap indefinitely?
-
----
-
-## Q3 — Self-sponsored bounty policy
-
-**Status:** Open.
-
-Risk: maintainer sponsors their own issue, then picks which PR to merge. Open-competition mechanism breaks if the sponsor is also the adjudicator.
-
-Three options:
-
-1. **Block** — maintainer cannot sponsor own repos. Cleanest but excludes maintainers from funding their own roadmap.
-2. **Flag** — allow it, but display "self-sponsored — sponsor is also merge authority" prominently on the issue. Lets the market decide.
-3. **Third-party validator** — self-sponsored bounties require a designated reviewer who isn't the sponsor or the solver. Heavier, but actually preserves the mechanism.
-
-**To decide:** which? Probably (2) at v1, escalate to (3) only if abuse observed.
-
----
-
-## Q4 — Listing fee structure
-
-**Status:** Open.
-
-Revenue model under Path B includes a listing fee (sponsor pays to surface a bounty on the ranked board).
-
-- Flat fee (e.g. €5 per listing)?
-- Scaled fee (% of bounty amount, e.g. 3%)?
-- Tiered (free below €X, then scaled)?
-- Free to list, paid for featured placement only?
-
-**Tension:** flat fee deters tiny bounties (bad — multi-sponsor needs small contributions to work). Scaled fee feels Stripe-like and might trigger payment-services questions. Free-to-list with paid featured placement is cleanest legally but reduces revenue floor.
-
-**Default lean:** free to list (multi-sponsor flow shouldn't have entry friction); revenue comes from featured placement + premium API + rail kickback. Reconsider only if revenue doesn't materialize.
-
----
-
-## Q5 — GitHub-only at v1, or design for GitLab/Codeberg from the start?
-
-**Status:** Open. Likely "GitHub-only at v1" but worth naming.
-
-The "merged PR = bounty closes" mechanic is GitHub-shaped. v1 board could ingest from GitLab and Codeberg with adapter work, but it adds complexity for a small slice of the OSS market.
-
-**Default lean:** GitHub-only at v1. Revisit at v2. Document the adapter shape now so the data model doesn't lock us out later.
+Live decision deck for Bount.ing v2. Decisions move to [V2_THESIS.md](V2_THESIS.md) and the Decisions Log (bottom of this file) as they're settled.
 
 ---
 
@@ -91,37 +8,120 @@ The "merged PR = bounty closes" mechanic is GitHub-shaped. v1 board could ingest
 
 **Status:** Open — this is the v0.5 deliverable.
 
-`impact_score` is a function over observable signals. v0.5 will derive it from the v0 hand-weights in `bounties.yaml`. Candidate signals:
+`impact_score` is a function over observable signals. v0.5 will derive it from the v0 hand-weights in `bounties.yaml`. **First signal set to try (locked 2026-05-14):**
 
-| Signal | Source | Cost to compute |
-|---|---|---|
-| Repo star count | GitHub API | trivial |
-| Dependency-graph reach (who imports this) | npm/PyPI/crates.io/Cargo.toml/etc. | medium |
-| Issue 👍 reactions | GitHub API | trivial |
-| Maintainer responsiveness | GitHub API (time-to-first-reply) | medium |
-| Blocks-downstream signal | issue body parsing (`Closes #X`, references) | hard |
-| Security relevance | label heuristics + CVE feed cross-reference | medium |
-| Effort estimate | comment volume / referenced files / LOC of context | hard |
+| Signal | Source | Cost to compute | Weight intuition |
+|---|---|---|---|
+| Repo star count | GitHub API | trivial | log-scaled, modest |
+| Issue 👍 reactions | GitHub API | trivial | linear, modest |
+| Dependency-graph reach | npm / PyPI / crates / Cargo.toml | medium | log-scaled, high (network effect) |
+| Blocks-downstream signal | issue body parsing (`Closes #X`, references) | hard but worth it | linear, high |
+| Security relevance | label heuristics + CVE feed cross-reference | medium | binary boost |
+| Maintainer responsiveness | GitHub API (time-to-first-reply) | medium | tiebreaker, modest |
 
-**To do at v0.5:** pick 3–4 signals, fit weights against `bounties.yaml`, see if reproduces ≥80%. If not, iterate.
+**v0.5 deliverable:** fit weights against `bounties.yaml`, target ≥80% reproduction of hand-weights. Iterate. Move full formula to V2_THESIS.md when stable.
 
 ---
 
-## Q7 — Repo organization for v2 build
+## Q1.7 — Host bount.ing itself on Open Collective Europe?
 
-**Status:** Open.
+**Status:** Settled lean (locked 2026-05-14), execution-detail open.
 
-v1 code lives in this repo (`api/`, `wui/`, `dcdn/` submodules — Go backend, Vue 3 frontend, Docker Compose). v2 is a different product with different mechanism design.
+**Decision:** Yes. Host bount.ing on Open Collective Europe (or equivalent OCE fiscal host under the OC umbrella).
 
-Options:
-1. **Rebuild in-place** — replace `api/` and `wui/` content. Lose v1 history in the working tree but keep it in git history.
-2. **Branch** — `v1` branch preserves shipped state, `master` rebuilds for v2.
-3. **Greenfield** — archive this repo, start fresh at a new repo. Preserves clean history; loses domain authority.
+**Why:**
+- Cleaner legal shell than re-opening Bount.ing S.L. during the autónomo bleed.
+- Listing fees + premium API + featured-placement revenue flows into the bount.ing OC project.
+- Mía draws monthly autónomo invoice against the project balance (standard EUR invoice flow, matches Foqum/RugbyTour7 posture).
+- OCE handles VAT, transparency ledger, contributor compensation.
+- Host fee: typically 5–10% of inflows. Versus €6k SL setup + ongoing cuota societaria — vastly cheaper.
 
-**Default lean:** option 2 (branch off `v1`, rebuild on `master`). Preserves authorship trail, keeps the repo name + GitHub stars + history, lets v1 stay reachable for archival reference.
+**Open execution sub-questions:**
+- Which fiscal host under OC exactly? OCE is one option; there are others (Open Source Collective, etc.). Verify at v2 launch prep.
+- Transparency ledger publishes every transaction publicly — fine for OSS values alignment, worth confirming the sponsor pool is comfortable being on it.
+
+---
+
+## Q8 — Curve implementation depth at v2 launch
+
+**Status:** Open. Depends on Q2 settlement + engineering reality at launch time.
+
+Two ships:
+
+| Option | Description |
+|---|---|
+| **Full euro-curves** | Sponsor pre-funds curve_max (appreciation) or commits with decay-redirect policy (decay). Actual euro value moves over time per the curve. Solver receives curve-value-at-close. |
+| **Flat-bounty + curve-as-ranking** | Bounty euro value is flat at contribution-time. Curve only affects queue ranking (decay = slides down the queue; appreciation = climbs the queue). Cleaner to implement, ships v2 faster. |
+
+**Default:** ship flat + ranking-only at v2 launch if full euro-curves aren't engineering-ready. Full euro-curves arrive at v2.5. Better to ship flat-but-real than complex-but-broken.
+
+**Decision trigger:** engineering readiness check 2 weeks before v2 launch. If full curves not ready, ship flat + ranking-only.
 
 ---
 
 ## Decisions log (settled)
 
-*(empty — move resolved questions here with the decision and date)*
+### Q1 — Rail integration sequence (resolved 2026-05-14)
+
+**Decision:** Multi-rail at v2 launch, provider-agnostic. Sequence by administrative/financial fit with current autónomo posture:
+
+1. **Open Collective** — v2 launch. EUR invoices match existing Foqum/RugbyTour7 flow, fiscal-host model means OC carries pooling compliance. Zero new tax categories.
+2. **GitHub Sponsors** — v2.1. Admin-trivial (pure read-API integration), but mechanism-poor (single-sponsor only).
+3. **Drips Network** — v2.5, after autónomo books stabilize. Mechanism-fit (streaming = appreciation) and values-fit, but adds crypto-as-business-income reporting overhead (Modelo 720/721, IRPF treatment ambiguity, segregation of personal vs. business wallets). Not while RETA arrears are in aplazamiento.
+4. **GNU Taler** — when (a) a production EU exchange settles to Spanish banks with non-trivial reach, AND (b) at least one v2 sponsor requests it, AND/OR (c) NLnet grant capture makes Taler-extension engineering feasible.
+
+**Rationale:** filtered through administrative/financial-fit criterion, not personal-affinity. OC's fiscal-host model slots into the existing autónomo invoicing flow with no new tax categories. Drips deferred because crypto-business-income reporting is the worst thing to add right now.
+
+**Architectural implication:** bount.ing v2 is a **federation layer** over funding rails. Adapter pattern, one per rail. Mirrors Lethe's multi-provider LLM pattern.
+
+### Q2 — Curve presets (resolved 2026-05-14)
+
+**Decision:** Three presets, locked.
+
+| Preset | Shape | Floor / cap |
+|---|---|---|
+| `urgent` | Linear decay over 30d | Floor = 25% of initial |
+| `standard` | Flat 30d → linear decay 60d to floor | Floor = 25% of initial |
+| `patient` | Linear appreciation | Cap = 3× initial OR T+90d, whichever first |
+
+**Sub-decisions:**
+- Floor type: **fixed %** of initial (scales with bounty size; absolute floors would break for €5 and €5000 bounties alike).
+- Appreciation cap: **pool-lifetime, not reset on new sponsors** (else gameable — sponsors would add late contributions to extend the cap).
+- Post-terminal behavior: bounty stays at floor/cap until close. **Hard expire at T+180d** → unresolved pool re-routes per sponsor's pre-set destination policy.
+
+**Implementation against OC:**
+- **Decay:** decayed portion is *re-routed*, not refunded (refunds = fund-custody = autónomo poison). Sponsor picks destination at creation: default = bount.ing platform fund / community treasury / other underfunded bounties.
+- **Appreciation:** sponsor pre-funds the curve_max upfront. Solver receives curve-value-at-close. Difference re-routes per sponsor's pre-set destination policy (same dropdown as decay). Sponsor knows max liability at creation; no escrow gymnastics.
+- See Q8 for v2-launch fallback if full euro-curves aren't engineering-ready.
+
+### Q3 — Self-sponsored bounty policy (resolved 2026-05-14)
+
+**Decision:** Flag at v1, escalate later if abused.
+
+Maintainer can sponsor own issue. UI displays "self-sponsored — sponsor is also merge authority" on the issue. Solvers see it before attempting. Escalate to third-party validator only if abuse pattern observed.
+
+### Q4 — Listing fee structure (resolved 2026-05-14)
+
+**Decision:** Free to list. Revenue from three other layers:
+
+1. **Featured placement** — sponsor pays for top-of-queue visibility within their tag/repo
+2. **Premium API** — agent fleets, subscription-based
+3. **Rail kickback** where supported (Drips natively; OC via host-fee-share if negotiable)
+
+**Why:** entry friction breaks the multi-sponsor pooling mechanic (differentiator #1). Free-to-list keeps the crowdfunded flow frictionless. Reconsider only if revenue doesn't materialize.
+
+### Q5 — GitHub-only at v1 (resolved 2026-05-14)
+
+**Decision:** GitHub-only at v1. Data model supports adapter shape for GitLab / Codeberg / forgejo at v2+.
+
+Don't ship multi-platform before the GitHub experience is solid. Document the adapter interface now so the data model doesn't lock us out later.
+
+### Q7 — Repo organization for v2 build (resolved 2026-05-14)
+
+**Decision:** Branch `v1` from current `master`, rebuild v2 on `master`.
+
+- Preserves authorship trail + GitHub stars + repo history.
+- v1 stays reachable for archival reference (PROCESS.md, TESTS.md, 2024 codebase).
+- v2 ships on clean `master`.
+- 112 v1 CVEs become "v1 branch is archival, security alerts not blocking v2."
+- `v1` branch created as part of this PR (defensive — locks in v1 state before any v2 work touches `master`).

--- a/docs/V2_THESIS.md
+++ b/docs/V2_THESIS.md
@@ -36,10 +36,25 @@ Bounty value follows a curve, not a flat number.
 | **Decay** (€ drops over time) | Forces solver urgency. Dutch-auction shape. | Security patches, business-critical bugs, time-sensitive launches |
 | **Appreciation** (€ grows over time) | Solves the neglected-good-issue problem — eventually stale issues become attractive | Long-tail OSS maintenance, refactors, "nice but not urgent" features |
 
+**Three presets** (locked 2026-05-14):
+
+| Preset | Shape | Floor / cap |
+|---|---|---|
+| `urgent` | Linear decay over 30d | Floor = 25% of initial |
+| `standard` | Flat 30d → linear decay 60d to floor | Floor = 25% of initial |
+| `patient` | Linear appreciation | Cap = 3× initial OR T+90d, whichever first |
+
 Design constraints:
-- 3 presets only at creation (`urgent` / `standard` / `patient`). No adversarial custom curves.
-- Appreciation capped at 3× initial or sunsets at T+90d. Unbounded growth = hoarding.
-- Pool-wide clock (not per-contribution). Simpler, prevents micro-gaming.
+- 3 presets only at creation. No custom curves (predatory shapes would game solvers).
+- Floor is a **percentage** of initial, not absolute (scales with bounty size).
+- Appreciation cap is **pool-lifetime**, not reset on new sponsors (else gameable).
+- Pool-wide clock (not per-contribution).
+- Hard expire at T+180d → unresolved pool re-routes per sponsor's pre-set destination policy.
+
+**Implementation against the integrated rail (OC at v2 launch):**
+- **Decay:** decayed portion is *re-routed*, not refunded (refunds = fund-custody = autónomo poison). Sponsor picks destination at creation: bount.ing platform fund / community treasury / other underfunded bounties.
+- **Appreciation:** sponsor pre-funds the curve_max upfront. Solver receives curve-value-at-close. Difference re-routes per sponsor's pre-set destination policy. Sponsor knows max liability at creation.
+- **v2-launch fallback:** if full euro-curves aren't engineering-ready, ship flat + curve-as-ranking-only (curve affects queue position but not euro value). Full euro-curves at v2.5. See OPEN_QUESTIONS.md Q8.
 
 **Solves:** static-bounty staleness. None of the graveyard platforms have this.
 
@@ -81,23 +96,34 @@ Bounty size encodes impact for the funded queue (market-priced). The platform's 
           ▼                                     ▼
     Solver view                          Pooling rails
     (ranked queue)                       ┌─────────────────┐
-                                         │ Drips / OC /    │
-    Sponsor view                         │ Gitcoin Allo /  │
-    (impact ÷ funding)                   │ GH Sponsors     │
+                                         │ OC → GH Sponsors│
+    Sponsor view                         │ → Drips →       │
+    (impact ÷ funding)                   │ Taler (phased)  │
                                          └─────────────────┘
                                                 ▼
                                          Maintainers / Solvers
 ```
 
-Pooling happens on existing fiscal-host rails (Drips Network, Open Collective, Gitcoin Allo, GitHub Sponsors). Compliance is handled by the rails. Bount.ing owns the algorithm and the surface, not the money.
+Pooling happens on existing fiscal-host rails (Open Collective, GitHub Sponsors, Drips Network, GNU Taler). Compliance is handled by the rails. Bount.ing owns the algorithm and the surface, not the money.
+
+**Provider-agnostic by design.** Bount.ing v2 is a federation layer over funding rails — adapter pattern, one per rail. Sponsor picks the rail when funding a bounty. Mirrors Lethe's multi-provider LLM pattern.
+
+**Rail integration sequence** (resolved 2026-05-14, see OPEN_QUESTIONS.md Decisions Log Q1):
+
+1. **Open Collective** — v2 launch. Fiscal-host model matches existing autónomo invoicing flow; zero new tax categories.
+2. **GitHub Sponsors** — v2.1. Admin-trivial; mechanism-poor (single-sponsor only).
+3. **Drips Network** — v2.5, after autónomo books stabilize. Mechanism-fit (streaming = appreciation curve) but adds crypto-as-business-income reporting overhead.
+4. **GNU Taler** — when EU exchange ecosystem matures and/or NLnet grant capture funds protocol-extension engineering.
 
 **Path A (own pooling rails, SL needed)** is deferred to v3 (2027+) — triggered by platform revenue > €1k/mo recurring and strategic need to hold funds.
 
-Revenue model under Path B (all invoiceable as autónomo):
-- **Listing fee** — sponsor pays €5–€20 to surface a bounty on the ranked board
-- **Premium API** — agent fleets that consume the queue programmatically
-- **Featured placement** — high-trust sponsors get priority surface
-- **Cut-on-close** — where integrated rails support kickback (Drips does)
+**Bount.ing as a hosted OC project.** The platform itself is hosted on Open Collective Europe (or equivalent OCE fiscal host). Listing fees + premium API + featured-placement revenue flows into the bount.ing OC project. Mía draws monthly autónomo invoice against project balance. OCE handles VAT + transparency ledger + contributor compensation. Host fee 5–10% — vastly cheaper than €6k SL setup + cuota societaria.
+
+Revenue model under Path B (all invoiceable as autónomo via OCE):
+- **Featured placement** — sponsor pays for top-of-queue visibility within their tag/repo
+- **Premium API** — agent fleets, subscription-based
+- **Rail kickback** — Drips natively; OC via host-fee-share if negotiable
+- **Listing: free** — entry friction breaks the multi-sponsor pooling mechanic (differentiator #1)
 
 ## Phased roadmap
 
@@ -118,7 +144,7 @@ Revenue model under Path B (all invoiceable as autónomo):
 
 ## Risks
 
-- **Maintainer-as-merger conflict of interest.** If a maintainer sponsors their own issue and picks the winning PR, open competition breaks. Mitigation: self-sponsored bounties require third-party validation or are flagged.
+- **Maintainer-as-merger conflict of interest.** If a maintainer sponsors their own issue and picks the winning PR, open competition breaks. Mitigation (locked 2026-05-14): self-sponsored bounties are **flagged** in the UI ("self-sponsored — sponsor is also merge authority") at v1; escalate to third-party validator only if abuse pattern observed.
 - **Wasted effort from open competition.** N solvers attempt, 1 wins. Mitigation: show "active attempt count" per issue; optional staked claim as v1+ safety valve.
 - **Decay-curve adversarial design.** Predatory curves (€100 → €1 in 24h) game solvers. Mitigation: 3 presets, no custom.
 - **GitHub lock-in.** "Merged PR = closed" is GitHub-shaped. Locks out GitLab / Codeberg. Acceptable v1 cost; revisit at v2.


### PR DESCRIPTION
## Summary
Resolves the 7 open questions opened in #100 plus one bonus (Q1.7) and surfaces two new live questions (Q6 deferred to v0.5, Q8 a launch-readiness call).

### Decisions locked

- **Q1 — Rail sequence:** provider-agnostic federation. OC (v2 launch) → GH Sponsors (v2.1) → Drips (v2.5, after autónomo books stabilize) → Taler (ecosystem/grant-gated). Filtered by administrative/financial fit, not personal affinity.
- **Q1.7 — Host bount.ing on Open Collective Europe.** Cleaner shell than re-opening the dissolved SL; OCE handles VAT/transparency/contributor compensation at 5–10% host fee.
- **Q2 — Curve presets:** `urgent` (linear decay 30d → 25% floor), `standard` (flat 30d → decay 60d → 25% floor), `patient` (linear appreciation, cap 3× or T+90d). Decay re-routes (no refunds); appreciation pre-funded.
- **Q3 — Self-sponsored bounties:** flag in UI at v1, escalate later only if abused.
- **Q4 — Listing fee:** free. Revenue from featured placement + premium API + rail kickback.
- **Q5 — GitHub-only at v1.** Data model supports adapter shape for GitLab / Codeberg / forgejo at v2+.
- **Q7 — Repo organization:** v1 branch (archival) created from current master; v2 rebuild on master.

### Live questions

- **Q6 — `impact_score` definition:** v0.5 deliverable (this is the work). First signal set locked: stars, 👍, dependency reach, blocks-graph, security label, maintainer responsiveness.
- **Q8 — Curve implementation depth at launch:** full euro-curves vs flat+ranking-only. Decision at engineering-readiness check 2 weeks pre-launch.

### Companion change

`v1` archival branch pushed in this PR series — preserves the 2024 codebase + history before v2 rebuild touches master. Resolves the 112-CVE legacy issue (alerts now scoped to archival branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)